### PR TITLE
This will catch errors when opening the hidraw files and report EACCES on stderr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This tool uses the `hidraw` driver and needs at least *Linux 2.6.30* in order
 to work. It can only write settings, not read them, so you have to set
 everything at the same same.
 
+On some systems the hidraw devide files are readable only by root, so you
+might need to run this as root.
+
 Usage
 =====
 

--- a/tpkbdctl.c
+++ b/tpkbdctl.c
@@ -4,6 +4,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
@@ -32,8 +33,11 @@ int find_device() {
 	for (i=0; i<255; i++) {
 		snprintf(name, 255, "/dev/hidraw%d", i);
 		fd = open(name, O_RDWR|O_NONBLOCK);
-		if (!fd)
+		if (fd == -1) {
+			if (errno == EACCES)
+				fprintf(stderr, "Permission denied on %s\n", name);
 			continue;
+		}
 
 		ret = ioctl(fd, HIDIOCGRAWINFO, &devinfo);
 		if (ret) {


### PR DESCRIPTION
Hi Bernhard,

On my Ubuntu 12.04 machine, the /dev/hidraw\* files are readable only by root but tpkbdctl would only report that no device was found, so it took me a little while to figure out that was because my user had no permission to read from /dev/hidraw*.  I'm not sure whether that's expected but I think it won't hurt to report EACCES. If you'd prefer I'm happy to change this patch so that EACCES is reported only when verbosity>0.

Once again, thanks a lot for making this available!
