### PR TITLE
README.rst > Permanent Setup > rm '-d ${DEVPATH}'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Don't forget to make it executable by running ``chmod 755 /etc/udev/tpkbdctl_run
 
     #!/bin/sh
     
-    /usr/bin/tpkbdctl -d ${DEVPATH} -s 192 # your settings here
+    /usr/bin/tpkbdctl  -s 192 # your settings here
 
 See also
 ========


### PR DESCRIPTION
Leaving out the '-d ${DEVPATH}' part makes the settings work.

Tested on a single-keyboard machine:

Linux hostname 3.13.0-30-generic #54-Ubuntu SMP Mon Jun 9 22:45:01 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
